### PR TITLE
Add IP validation, device history and broken flag

### DIFF
--- a/public/database.js
+++ b/public/database.js
@@ -11,7 +11,8 @@ class Database {
             searchInventory: '/api/search-inventory',
             importExcel: '/api/import-excel',
             importedComputers: '/api/imported-computers',
-            migrateImported: '/api/migrate-imported'
+            migrateImported: '/api/migrate-imported',
+            history: '/api/history'
         };
     }
 
@@ -72,6 +73,15 @@ class Database {
         } catch (error) {
             console.error('Ошибка миграции данных:', error);
             throw error;
+        }
+    }
+
+    async getHistory() {
+        try {
+            return await this.apiRequest(this.endpoints.history);
+        } catch (error) {
+            console.error('Ошибка получения истории:', error);
+            return [];
         }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -340,6 +340,9 @@
                     <label for="computerNotes">Особенности/Проблемы:</label>
                     <textarea id="computerNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label><input type="checkbox" id="computerBroken"> Неисправно</label>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('computerModal')">Отмена</button>
@@ -413,6 +416,9 @@
                     <label for="networkNotes">Примечания:</label>
                     <textarea id="networkNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label><input type="checkbox" id="networkBroken"> Неисправно</label>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('networkModal')">Отмена</button>
@@ -471,6 +477,9 @@
                 <div class="form-group">
                     <label for="otherNotes">Примечания:</label>
                     <textarea id="otherNotes" rows="3"></textarea>
+                </div>
+                <div class="form-group">
+                    <label><input type="checkbox" id="otherBroken"> Неисправно</label>
                 </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>

--- a/public/script.js
+++ b/public/script.js
@@ -245,6 +245,7 @@ function openComputerModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('computerBroken').checked = false;
         
         // Сбрасываем состояние поиска
         resetInventorySearch();
@@ -286,6 +287,7 @@ async function editComputer(id) {
         document.getElementById('computerName').value = computer.computerName || '';
         document.getElementById('computerYear').value = computer.year || '';
         document.getElementById('computerNotes').value = computer.notes || '';
+        document.getElementById('computerBroken').checked = computer.status === 'broken';
 
         resetInventorySearch();
         document.getElementById('computerModal').style.display = 'block';
@@ -406,6 +408,7 @@ function openNetworkModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('networkBroken').checked = false;
         
         document.getElementById('networkModal').style.display = 'block';
     } catch (error) {
@@ -441,6 +444,7 @@ async function editNetworkDevice(id) {
         document.getElementById('networkWifiName').value = device.wifiName || '';
         document.getElementById('networkWifiPassword').value = device.wifiPassword || '';
         document.getElementById('networkNotes').value = device.notes || '';
+        document.getElementById('networkBroken').checked = device.status === 'broken';
 
         document.getElementById('networkModal').style.display = 'block';
     } catch (error) {
@@ -560,6 +564,7 @@ function openOtherModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('otherBroken').checked = false;
         
         document.getElementById('otherModal').style.display = 'block';
     } catch (error) {
@@ -592,6 +597,7 @@ async function editOtherDevice(id) {
         document.getElementById('otherResponsible').value = device.responsible || '';
         document.getElementById('otherInventoryNumber').value = device.inventoryNumber || '';
         document.getElementById('otherNotes').value = device.notes || '';
+        document.getElementById('otherBroken').checked = device.status === 'broken';
 
         document.getElementById('otherModal').style.display = 'block';
     } catch (error) {
@@ -792,7 +798,7 @@ async function renderIPAddressTable() {
         computers.forEach(computer => {
             if (computer.ipAddress && computer.ipAddress.startsWith('192.168.100.')) {
                 usedIPs.set(computer.ipAddress, {
-                    type: 'Компьютер',
+                    type: computer.deviceType || 'Компьютер',
                     name: computer.computerName || computer.model || 'Неизвестно',
                     location: computer.location || '',
                     status: computer.status || 'working'
@@ -935,7 +941,8 @@ async function handleComputerSubmit(e) {
             ipAddress: document.getElementById('computerIpAddress').value.trim(),
             computerName: document.getElementById('computerName').value.trim(),
             year: document.getElementById('computerYear').value.trim(),
-            notes: document.getElementById('computerNotes').value.trim()
+            notes: document.getElementById('computerNotes').value.trim(),
+            status: document.getElementById('computerBroken').checked ? 'broken' : undefined
         };
 
         console.log('📝 Данные формы:', formData);
@@ -993,7 +1000,8 @@ async function handleNetworkSubmit(e) {
             password: document.getElementById('networkPassword').value.trim(),
             wifiName: document.getElementById('networkWifiName').value.trim(),
             wifiPassword: document.getElementById('networkWifiPassword').value.trim(),
-            notes: document.getElementById('networkNotes').value.trim()
+            notes: document.getElementById('networkNotes').value.trim(),
+            status: document.getElementById('networkBroken').checked ? 'broken' : undefined
         };
 
         // Валидация
@@ -1044,7 +1052,8 @@ async function handleOtherSubmit(e) {
             location: document.getElementById('otherLocation').value.trim(),
             responsible: document.getElementById('otherResponsible').value.trim(),
             inventoryNumber: document.getElementById('otherInventoryNumber').value.trim(),
-            notes: document.getElementById('otherNotes').value.trim()
+            notes: document.getElementById('otherNotes').value.trim(),
+            status: document.getElementById('otherBroken').checked ? 'broken' : undefined
         };
 
         // Валидация


### PR DESCRIPTION
## Summary
- ensure IP uniqueness across computers and network devices
- log device modifications to new `device_history` table
- show device type correctly in IP table
- allow marking devices as broken via checkbox
- expose `/api/history` endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853b08670a083269b358a613e0f4bff