### PR TITLE
Add IP validation, device history and broken flag

### DIFF
--- a/public/database.js
+++ b/public/database.js
@@ -11,7 +11,8 @@ class Database {
             searchInventory: '/api/search-inventory',
             importExcel: '/api/import-excel',
             importedComputers: '/api/imported-computers',
-            migrateImported: '/api/migrate-imported'
+            migrateImported: '/api/migrate-imported',
+            history: '/api/history'
         };
     }
 
@@ -72,6 +73,15 @@ class Database {
         } catch (error) {
             console.error('Ошибка миграции данных:', error);
             throw error;
+        }
+    }
+
+    async getHistory() {
+        try {
+            return await this.apiRequest(this.endpoints.history);
+        } catch (error) {
+            console.error('Ошибка получения истории:', error);
+            return [];
         }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,7 @@
             <button class="tab-button" onclick="openTab(event, 'other')">🖨️ Другая техника</button>
             <button class="tab-button" onclick="openTab(event, 'assigned')">👤 Персональные устройства</button>
             <button class="tab-button" onclick="openTab(event, 'ipaddresses')">📊 IP адреса</button>
+            <button class="tab-button" onclick="openTab(event, 'history')">🕘 История</button>
         </div>
 
         <!-- Вкладка "Компьютеры" -->
@@ -247,6 +248,30 @@
                 </table>
             </div>
         </div>
+
+        <!-- Вкладка "История" -->
+        <div id="history" class="tab-content">
+            <div class="controls">
+                <h3>🕘 История изменений</h3>
+            </div>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>№</th>
+                            <th>Таблица</th>
+                            <th>Инв.номер</th>
+                            <th>Название</th>
+                            <th>Действие</th>
+                            <th>Время</th>
+                        </tr>
+                    </thead>
+                    <tbody id="historyTable">
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
 
     <!-- Модальные окна -->
@@ -340,6 +365,14 @@
                     <label for="computerNotes">Особенности/Проблемы:</label>
                     <textarea id="computerNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label for="computerStatus">Состояние:</label>
+                    <select id="computerStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('computerModal')">Отмена</button>
@@ -413,6 +446,14 @@
                     <label for="networkNotes">Примечания:</label>
                     <textarea id="networkNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label for="networkStatus">Состояние:</label>
+                    <select id="networkStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('networkModal')">Отмена</button>
@@ -471,6 +512,14 @@
                 <div class="form-group">
                     <label for="otherNotes">Примечания:</label>
                     <textarea id="otherNotes" rows="3"></textarea>
+                </div>
+                <div class="form-group">
+                    <label for="otherStatus">Состояние:</label>
+                    <select id="otherStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
                 </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>

--- a/public/script.js
+++ b/public/script.js
@@ -125,6 +125,9 @@ async function renderTabContent(tabName) {
             case 'ipaddresses':
                 await renderIPAddressTable();
                 break;
+            case 'history':
+                await renderHistory();
+                break;
             default:
                 console.warn('Неизвестная вкладка:', tabName);
         }
@@ -245,6 +248,7 @@ function openComputerModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('computerStatus').value = 'working';
         
         // Сбрасываем состояние поиска
         resetInventorySearch();
@@ -286,6 +290,7 @@ async function editComputer(id) {
         document.getElementById('computerName').value = computer.computerName || '';
         document.getElementById('computerYear').value = computer.year || '';
         document.getElementById('computerNotes').value = computer.notes || '';
+        document.getElementById('computerStatus').value = computer.status || 'working';
 
         resetInventorySearch();
         document.getElementById('computerModal').style.display = 'block';
@@ -406,6 +411,7 @@ function openNetworkModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('networkStatus').value = 'working';
         
         document.getElementById('networkModal').style.display = 'block';
     } catch (error) {
@@ -441,6 +447,7 @@ async function editNetworkDevice(id) {
         document.getElementById('networkWifiName').value = device.wifiName || '';
         document.getElementById('networkWifiPassword').value = device.wifiPassword || '';
         document.getElementById('networkNotes').value = device.notes || '';
+        document.getElementById('networkStatus').value = device.status || 'working';
 
         document.getElementById('networkModal').style.display = 'block';
     } catch (error) {
@@ -560,6 +567,7 @@ function openOtherModal() {
         if (form) {
             form.reset();
         }
+        document.getElementById('otherStatus').value = 'working';
         
         document.getElementById('otherModal').style.display = 'block';
     } catch (error) {
@@ -592,6 +600,7 @@ async function editOtherDevice(id) {
         document.getElementById('otherResponsible').value = device.responsible || '';
         document.getElementById('otherInventoryNumber').value = device.inventoryNumber || '';
         document.getElementById('otherNotes').value = device.notes || '';
+        document.getElementById('otherStatus').value = device.status || 'working';
 
         document.getElementById('otherModal').style.display = 'block';
     } catch (error) {
@@ -792,7 +801,7 @@ async function renderIPAddressTable() {
         computers.forEach(computer => {
             if (computer.ipAddress && computer.ipAddress.startsWith('192.168.100.')) {
                 usedIPs.set(computer.ipAddress, {
-                    type: 'Компьютер',
+                    type: computer.deviceType || 'Компьютер',
                     name: computer.computerName || computer.model || 'Неизвестно',
                     location: computer.location || '',
                     status: computer.status || 'working'
@@ -913,6 +922,37 @@ function assignIP(ip) {
     }
 }
 
+// === ИСТОРИЯ ИЗМЕНЕНИЙ ===
+async function renderHistory() {
+    console.log('📜 Загрузка истории изменений');
+
+    try {
+        const history = await db.getHistory();
+        const tbody = document.getElementById('historyTable');
+        if (!tbody) {
+            console.error('❌ Элемент historyTable не найден');
+            return;
+        }
+
+        tbody.innerHTML = '';
+
+        history.forEach((item, index) => {
+            tbody.innerHTML += `
+                <tr>
+                    <td>${index + 1}</td>
+                    <td>${escapeHtml(item.table)}</td>
+                    <td>${escapeHtml(item.inventoryNumber || '')}</td>
+                    <td>${escapeHtml(item.name || '')}</td>
+                    <td>${escapeHtml(item.action)}</td>
+                    <td>${new Date(item.timestamp).toLocaleString()}</td>
+                </tr>
+            `;
+        });
+    } catch (error) {
+        console.error('Ошибка загрузки истории:', error);
+    }
+}
+
 // === ОБРАБОТЧИКИ ФОРМ ===
 
 // Добавляем обработку формы компьютеров
@@ -935,7 +975,8 @@ async function handleComputerSubmit(e) {
             ipAddress: document.getElementById('computerIpAddress').value.trim(),
             computerName: document.getElementById('computerName').value.trim(),
             year: document.getElementById('computerYear').value.trim(),
-            notes: document.getElementById('computerNotes').value.trim()
+            notes: document.getElementById('computerNotes').value.trim(),
+            status: document.getElementById('computerStatus').value
         };
 
         console.log('📝 Данные формы:', formData);
@@ -993,7 +1034,8 @@ async function handleNetworkSubmit(e) {
             password: document.getElementById('networkPassword').value.trim(),
             wifiName: document.getElementById('networkWifiName').value.trim(),
             wifiPassword: document.getElementById('networkWifiPassword').value.trim(),
-            notes: document.getElementById('networkNotes').value.trim()
+            notes: document.getElementById('networkNotes').value.trim(),
+            status: document.getElementById('networkStatus').value
         };
 
         // Валидация
@@ -1044,7 +1086,8 @@ async function handleOtherSubmit(e) {
             location: document.getElementById('otherLocation').value.trim(),
             responsible: document.getElementById('otherResponsible').value.trim(),
             inventoryNumber: document.getElementById('otherInventoryNumber').value.trim(),
-            notes: document.getElementById('otherNotes').value.trim()
+            notes: document.getElementById('otherNotes').value.trim(),
+            status: document.getElementById('otherStatus').value
         };
 
         // Валидация


### PR DESCRIPTION
## Summary
- ensure IP uniqueness across computers and network devices
- log device modifications to new `device_history` table
- show device type correctly in IP table
- allow marking devices as broken via checkbox
- expose `/api/history` endpoint
- add history viewing tab and status dropdowns
- store before/after changes in history records and display inventory numbers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853b08670a083269b358a613e0f4bff