### PR TITLE
Add IP validation, device history and broken flag

### DIFF
--- a/public/database.js
+++ b/public/database.js
@@ -11,7 +11,8 @@ class Database {
             searchInventory: '/api/search-inventory',
             importExcel: '/api/import-excel',
             importedComputers: '/api/imported-computers',
-            migrateImported: '/api/migrate-imported'
+            migrateImported: '/api/migrate-imported',
+            history: '/api/history'
         };
     }
 
@@ -72,6 +73,15 @@ class Database {
         } catch (error) {
             console.error('Ошибка миграции данных:', error);
             throw error;
+        }
+    }
+
+    async getHistory() {
+        try {
+            return await this.apiRequest(this.endpoints.history);
+        } catch (error) {
+            console.error('Ошибка получения истории:', error);
+            return [];
         }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -228,6 +228,10 @@
             <div class="controls">
                 <h3>📊 Таблица IP адресов сети 192.168.100.0/24</h3>
                 <p>Управление IP адресами от 192.168.100.1 до 192.168.100.254</p>
+                <div class="file-operations">
+                    <button class="btn btn-warning" onclick="exportToExcel('ipaddresses')">📤 Экспорт Excel</button>
+                    <button class="btn" onclick="exportData('ipaddresses')">📊 Экспорт JSON</button>
+                </div>
             </div>
 
             <div class="table-container">
@@ -253,6 +257,10 @@
         <div id="history" class="tab-content">
             <div class="controls">
                 <h3>🕘 История изменений</h3>
+                <div class="file-operations">
+                    <button class="btn btn-warning" onclick="exportToExcel('history')">📤 Экспорт Excel</button>
+                    <button class="btn" onclick="exportData('history')">📊 Экспорт JSON</button>
+                </div>
             </div>
 
             <div class="table-container">

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,7 @@
             <button class="tab-button" onclick="openTab(event, 'other')">🖨️ Другая техника</button>
             <button class="tab-button" onclick="openTab(event, 'assigned')">👤 Персональные устройства</button>
             <button class="tab-button" onclick="openTab(event, 'ipaddresses')">📊 IP адреса</button>
+            <button class="tab-button" onclick="openTab(event, 'history')">🕘 История</button>
         </div>
 
         <!-- Вкладка "Компьютеры" -->
@@ -247,6 +248,31 @@
                 </table>
             </div>
         </div>
+
+        <!-- Вкладка "История" -->
+        <div id="history" class="tab-content">
+            <div class="controls">
+                <h3>🕘 История изменений</h3>
+            </div>
+
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>№</th>
+                            <th>Таблица</th>
+                            <th>Инв.номер</th>
+                            <th>Название</th>
+                            <th>Действие</th>
+                            <th>Детали</th>
+                            <th>Время</th>
+                        </tr>
+                    </thead>
+                    <tbody id="historyTable">
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
 
     <!-- Модальные окна -->
@@ -340,6 +366,14 @@
                     <label for="computerNotes">Особенности/Проблемы:</label>
                     <textarea id="computerNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label for="computerStatus">Состояние:</label>
+                    <select id="computerStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('computerModal')">Отмена</button>
@@ -413,6 +447,14 @@
                     <label for="networkNotes">Примечания:</label>
                     <textarea id="networkNotes" rows="3"></textarea>
                 </div>
+                <div class="form-group">
+                    <label for="networkStatus">Состояние:</label>
+                    <select id="networkStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
+                </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>
                     <button type="button" class="btn" onclick="closeModal('networkModal')">Отмена</button>
@@ -471,6 +513,14 @@
                 <div class="form-group">
                     <label for="otherNotes">Примечания:</label>
                     <textarea id="otherNotes" rows="3"></textarea>
+                </div>
+                <div class="form-group">
+                    <label for="otherStatus">Состояние:</label>
+                    <select id="otherStatus">
+                        <option value="working">Исправен</option>
+                        <option value="issues">С проблемами</option>
+                        <option value="broken">Не исправен</option>
+                    </select>
                 </div>
                 <div class="modal-buttons">
                     <button type="submit" class="btn btn-success">💾 Сохранить</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -227,6 +227,11 @@ th, td {
     white-space: nowrap;
 }
 
+.wrap-cell {
+    white-space: normal;
+    word-break: break-word;
+}
+
 th {
     background: linear-gradient(45deg, #34495e, #2c3e50);
     color: white;


### PR DESCRIPTION
## Summary
- ensure IP uniqueness across computers and network devices
- log device modifications to new `device_history` table
- show device type correctly in IP table
- allow marking devices as broken via checkbox
- expose `/api/history` endpoint
- add history viewing tab and status dropdowns
- store before/after changes in history records and display inventory numbers
- translate history actions to Russian and add details column for before/after info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853b08670a083269b358a613e0f4bff